### PR TITLE
強制シーン遷移

### DIFF
--- a/Assets/Plugins/Free Stylized Skybox/Panoramic/Materials/Sky_Anime_03_Day_a.mat
+++ b/Assets/Plugins/Free Stylized Skybox/Panoramic/Materials/Sky_Anime_03_Day_a.mat
@@ -78,7 +78,7 @@ Material:
     - _OcclusionStrength: 1
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _Rotation: 353.71982
+    - _Rotation: 3.3229637
     m_Colors:
     - _Tint: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
   m_BuildTextureStacks: []

--- a/Assets/Scripts/Share/SceneManager.cs
+++ b/Assets/Scripts/Share/SceneManager.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -16,6 +17,7 @@ public class MySceneManager : MonoBehaviour
     {
         // 現在のシーン名を取得
         NowScene = SceneManager.GetActiveScene().name;
+        ForceChangeScene();
 
         if (NowScene == "Start" && flag)
         {
@@ -33,6 +35,25 @@ public class MySceneManager : MonoBehaviour
         {
             flag = false;
             SceneManager.LoadScene("Start");
+        }
+    }
+    private void ForceChangeScene()
+    {
+        // キーボードでシーン遷移
+        // 1: Start
+        // 2: Main
+        // 3: End
+        if (Input.GetKeyDown(KeyCode.Alpha1))
+        {
+            SceneManager.LoadScene("Start");
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha2))
+        {
+            SceneManager.LoadScene("Main");
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha3))
+        {
+            SceneManager.LoadScene("End");
         }
     }
 }


### PR DESCRIPTION
ゲームで不具合などが起きた時に強制的にPC側からシーン遷移の操作できるようにしました．

```
private void ForceChangeScene()
    {
        // キーボードでシーン遷移
        // 1: Start
        // 2: Main
        // 3: End
        if (Input.GetKeyDown(KeyCode.Alpha1))
        {
            SceneManager.LoadScene("Start");
        }
        else if (Input.GetKeyDown(KeyCode.Alpha2))
        {
            SceneManager.LoadScene("Main");
        }
        else if (Input.GetKeyDown(KeyCode.Alpha3))
        {
            SceneManager.LoadScene("End");
        }
    }
```